### PR TITLE
docs: fix repository name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ REST API платформа для загрузки данных (CSV/Excel) и 
 
 ### Установка
 ```bash
-git clone https://github.com/KuPriv/platformwithdashboards.git
-cd platformwithdashboards
+git clone https://github.com/KuPriv/platform-with-dashboards.git
+cd platform-with-dashboards
 
 poetry install
 cp .env.example .env


### PR DESCRIPTION
## What
Fixed incorrect repository name in README quick start section.

## Changes
- Updated `git clone` URL to match actual repository name
- Updated `cd` command accordingly