### PR TITLE
refactor: replace ModelViewSet with explicit mixins in DatasetViewSet

### DIFF
--- a/apps/datasets/views.py
+++ b/apps/datasets/views.py
@@ -1,5 +1,6 @@
-from rest_framework import viewsets
+from rest_framework import mixins
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.viewsets import GenericViewSet
 
 from apps.core.permissions import IsOwner
 
@@ -9,7 +10,13 @@ from .services import get_file_type
 from .tasks import process_dataset
 
 
-class DatasetViewSet(viewsets.ModelViewSet):
+class DatasetViewSet(
+    mixins.CreateModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.DestroyModelMixin,
+    mixins.ListModelMixin,
+    GenericViewSet,
+):
     serializer_class = DatasetSerializer
     permission_classes = [IsAuthenticated, IsOwner]
 


### PR DESCRIPTION
## What
- `ModelViewSet` заменён на явные миксины: `Create`, `Retrieve`, `Destroy`, `List`

## Why
- Датасет - загруженный файл, редактирование через API не предусмотрено по дизайну
- `PUT` и `PATCH` висели открытыми без необходимости
- Явные миксины документируют намерения — читающий код сразу видит что доступно