### PR TITLE
fix(datasets): make process_dataset atomic and resilient

### DIFF
--- a/apps/datasets/tasks.py
+++ b/apps/datasets/tasks.py
@@ -1,6 +1,7 @@
 import logging
 
 from celery import shared_task
+from django.db import transaction
 
 from apps.notifications.tasks import send_email
 
@@ -10,31 +11,34 @@ from .services import get_parsed_file
 logger = logging.getLogger(__name__)
 
 
-@shared_task(ignore_result=True)
-def process_dataset(dataset_id: int) -> None:
+@shared_task(ignore_result=True, bind=True, max_retries=3)
+def process_dataset(self, dataset_id: int) -> None:
     try:
         dataset = Dataset.objects.get(pk=dataset_id)
     except Dataset.DoesNotExist:
         logger.error("Dataset %s does not exist", dataset_id)
         return
     try:
-        dataset.status = dataset.Status.STARTED
-        dataset.save(update_fields=["status"])
-        df = get_parsed_file(dataset.file)
-        rows = [
-            DatasetRow(dataset=dataset, data=row.to_dict(), row_index=index)
-            for (index, row) in df.iterrows()
-        ]
-        DatasetRow.objects.bulk_create(rows, batch_size=1000)
-        dataset.status = dataset.Status.SUCCESS
-        dataset.save(update_fields=["status"])
-        send_email.delay(
-            dataset.user.id,
-            "Ваш датасет был обработан!",
-            "Датасет был обработан!\n Скорее заходите проверить!",
+        with transaction.atomic():
+            dataset.status = dataset.Status.STARTED
+            dataset.save(update_fields=["status"])
+            df = get_parsed_file(dataset.file)
+            rows = [
+                DatasetRow(dataset=dataset, data=row.to_dict(), row_index=index)
+                for (index, row) in df.iterrows()
+            ]
+            DatasetRow.objects.bulk_create(rows, batch_size=1000)
+            dataset.status = dataset.Status.SUCCESS
+            dataset.save(update_fields=["status"])
+        transaction.on_commit(
+            lambda: send_email.delay(
+                dataset.user.id,
+                "Ваш датасет был обработан!",
+                "Датасет был обработан!\n Скорее заходите проверить!",
+            )
         )
-    except Exception as e:
-        logger.error("process_dataset %s failed: %s", dataset_id, e)
+    except Exception as exc:
+        logger.error("process_dataset %s failed: %s", dataset_id, exc)
         dataset.status = dataset.Status.FAILURE
         dataset.save(update_fields=["status"])
         send_email.delay(
@@ -42,4 +46,4 @@ def process_dataset(dataset_id: int) -> None:
             "Ваш датасет не был обработан:(",
             "Произошла ошибка при обработке датасета. Попробуйте загрузить файл снова.",
         )
-        raise
+        raise self.retry(exc=exc)


### PR DESCRIPTION
## What
- Wrap dataset processing in `transaction.atomic()` to prevent dirty
  database state if processing fails midway
- Move `send_email.delay()` to `transaction.on_commit()` to ensure
  email is sent only after successful commit
- Add `bind=True` and `self.retry(exc=exc)` for automatic retries on failure

## Why
Previously, if `bulk_create` failed halfway through, the database would
be left in a dirty state - status stuck at `STARTED` with partial rows.
Also, `send_email.delay()` inside the try block could fire before the
transaction was committed, sending a success email even if the DB rolled back.

## Changes
- `apps/datasets/tasks.py`