### PR TITLE
fix(settings): add fallback SECRET_KEY for local development

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -1,6 +1,11 @@
+import os
+
 from .base import *  # noqa: F401, F403
 from .base import SPECTACULAR_SETTINGS
 
+SECRET_KEY = os.getenv(
+    "SECRET_KEY", "django-insecure-local-dev-only-do-not-use-in-production"
+)
 DEBUG = True
 
 ALLOWED_HOSTS = ["localhost", "127.0.0.1"]


### PR DESCRIPTION
## What
- Add default `SECRET_KEY` in `local.py` to prevent Django from
  failing with a cryptic error when `.env` is not configured
- Add explicit `import os` to avoid implicit dependency via `base import *`

## Why
`base.py` reads SECRET_KEY via `os.getenv("SECRET_KEY")` with no
fallback - if `.env` is missing or empty, Django crashes deep in
startup with an unhelpful error. Production should still fail loudly
(no fallback in base.py), but local development should work out of
the box after cloning the repo.

## Changes
- `config/settings/local.py`