### PR TITLE
fix: ensure celery task fires after db commit

### DIFF
--- a/apps/datasets/tasks.py
+++ b/apps/datasets/tasks.py
@@ -1,4 +1,5 @@
 import logging
+from functools import partial
 
 from celery import shared_task
 from django.db import transaction
@@ -30,8 +31,11 @@ def process_dataset(self, dataset_id: int) -> None:
             DatasetRow.objects.bulk_create(rows, batch_size=1000)
             dataset.status = dataset.Status.SUCCESS
             dataset.save(update_fields=["status"])
+        # on commit ensures email is sent only after the transaction
+        # is committed, preventing notification on rollback.
         transaction.on_commit(
-            lambda: send_email.delay(
+            partial(
+                send_email.delay,
                 dataset.user.id,
                 "Ваш датасет был обработан!",
                 "Датасет был обработан!\n Скорее заходите проверить!",

--- a/apps/datasets/views.py
+++ b/apps/datasets/views.py
@@ -1,3 +1,6 @@
+from functools import partial
+
+from django.db import transaction
 from rest_framework import mixins
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import GenericViewSet
@@ -22,4 +25,4 @@ class DatasetViewSet(
 
     def perform_create(self, serializer):
         dataset = serializer.save(user=self.request.user)
-        process_dataset.delay(dataset.pk)
+        transaction.on_commit(partial(process_dataset.delay, dataset.pk))


### PR DESCRIPTION
## What
- Wrap `process_dataset.delay` in `transaction.on_commit` in `perform_create`
- Add clarifying comment to `on_commit` call in `tasks.py`

## Why
Previously, `process_dataset.delay` was called immediately after `serializer.save`.
Since Django wraps view logic in a transaction, the Celery worker could receive
the task and query the database before the transaction was committed - resulting
in a DoesNotExist error.

Using `transaction.on_commit` guarantees the task is enqueued only after the
transaction is successfully committed. As a side effect, this also prevents
email notifications from being sent if the transaction is rolled back.