### PR TITLE
fix: patch transaction.on_commit in dataset upload test

### DIFF
--- a/apps/datasets/tests/test_views.py
+++ b/apps/datasets/tests/test_views.py
@@ -8,10 +8,11 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 def test_file_is_valid(api_client, user):
     api_client.force_authenticate(user=user)
     file = SimpleUploadedFile("test.csv", b"name,age\nEgor,22", content_type="text/csv")
-    with patch("apps.datasets.views.process_dataset.delay") as mock_task:
-        response = api_client.post(
-            "/api/v1/datasets/", {"name": "test", "file": file}, format="multipart"
-        )
+    with patch("apps.datasets.views.transaction.on_commit", lambda f: f()):
+        with patch("apps.datasets.views.process_dataset.delay") as mock_task:
+            response = api_client.post(
+                "/api/v1/datasets/", {"name": "test", "file": file}, format="multipart"
+            )
     assert response.status_code == 201
     mock_task.assert_called_once()
 


### PR DESCRIPTION
## What
- Patch `transaction.on_commit` to execute immediately in `test_file_is_valid`

## Why
`transaction.on_commit` callbacks are never executed in tests because
pytest-django wraps each test in a transaction that is rolled back, not committed.

Previously the test patched only `process_dataset.delay`, but the callback
was never reached - causing the assertion to fail after `on_commit` was introduced.