### PR TITLE
fix(settings): explicitly import os in production settings

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -1,3 +1,5 @@
+import os  # noqa: F401
+
 from .base import *  # noqa: F401, F403
 
 DEBUG = False


### PR DESCRIPTION
## What
- Add explicit `import os` to `production.py`

## Why
`os` was previously accessible only via `from .base import *`.
If `base.py` ever removes or changes its `os` import, `production.py`
would break silently at runtime. Explicit import makes the dependency clear
and independent of wildcard imports.