### PR TITLE
fix(datasets): add configurable file size limit on upload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,5 @@ GIST_COVERAGE_TOKEN=secret_key_from_github_for_gist
 GIST_COVERAGE_ID=gist_id_from_secrets_github
 
 SHOW_API_DOCS=True
+
+MAX_DATASET_UPLOAD_SIZE = 32 * 1024 * 1024 # 32MB default

--- a/apps/datasets/serializers.py
+++ b/apps/datasets/serializers.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from rest_framework import serializers
 
 from .models import Dataset
@@ -15,6 +16,11 @@ class DatasetSerializer(serializers.ModelSerializer):
         read_only_fields = ["file_type", "status"]
 
     def validate_file(self, value):
+        if value.size > settings.MAX_DATASET_UPLOAD_SIZE:
+            raise serializers.ValidationError(
+                f"Размер файла не должен превышать "
+                f"{settings.MAX_DATASET_UPLOAD_SIZE // 1024 // 1024}MB"
+            )
         ext = get_file_extension(value.name)
         if ext not in SUPPORTED_EXTENSIONS:
             raise serializers.ValidationError("Поддерживаются только CSV и Excel файлы")

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -189,3 +189,7 @@ LOGGING = {
 
 # EMAIL_SMTP
 DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "noreply@platform.com")
+
+MAX_DATASET_UPLOAD_SIZE = int(
+    os.getenv("MAX_DATASET_UPLOAD_SIZE", 8 * 1024 * 1024)
+)  # 8MB default


### PR DESCRIPTION
## What
- Add `MAX_DATASET_UPLOAD_SIZE` setting in `base.py` (default 8MB)
- Validate file size in `DatasetSerializer.validate_file` with a clear error message
- Add `MAX_DATASET_UPLOAD_SIZE` to `.env.example`

## Why
Previously there was no file size validation on dataset upload.
A user could upload an arbitrarily large file, which would be passed
to the Celery worker and loaded entirely into memory by pandas -
potentially causing OOM errors or slow processing.

The limit is configurable via environment variable to allow
different values across environments.