### PR TITLE
fix(env): use plain integer for MAX_DATASET_UPLOAD_SIZE in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,4 +29,4 @@ GIST_COVERAGE_ID=gist_id_from_secrets_github
 
 SHOW_API_DOCS=True
 
-MAX_DATASET_UPLOAD_SIZE = 32 * 1024 * 1024 # 32MB default
+MAX_DATASET_UPLOAD_SIZE = 33554432 # 32MB default


### PR DESCRIPTION
## What
- Replace Python expression with plain integer value in `.env.example`

## Why
`.env` files do not evaluate Python expressions - only plain values are supported.
Setting `32 * 1024 * 1024` would be read as a string and cause a TypeError
when cast to `int` in `base.py`.